### PR TITLE
Fix libopencm3 path managing

### DIFF
--- a/libopencm3.rules.mk
+++ b/libopencm3.rules.mk
@@ -56,10 +56,9 @@ ifeq ($(strip $(OPENCM3_DIR)),)
 # user has not specified the library path, so we try to detect it
 
 # where we search for the library
-LIBPATHS := ./libopencm3 ../libopencm3 ../../libopencm3 ../../../../../libopencm3
-
-OPENCM3_DIR := $(wildcard $(LIBPATHS:=/locm3.sublime-project))
-OPENCM3_DIR := $(firstword $(dir $(OPENCM3_DIR)))
+# credit: https://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+OPENCM3_DIR := $(patsubst %/,%,$(dir $(mkfile_path)))/libopencm3
 
 ifeq ($(strip $(OPENCM3_DIR)),)
 $(warning Cannot find libopencm3 library in the standard search paths.)


### PR DESCRIPTION
libopencm3 self path detection code seems was based on sublimetext project location: it seems to me only to work if such project has been created by the user (locm3.sublime-project technique seems to be used in 456 github files https://github.com/search?p=1&q=locm3.sublime-project&type=Code)

I'd like to try to propose more generic way